### PR TITLE
Briging back wallpaper to Anarchy Xfce4

### DIFF
--- a/extra/desktop/xfce4/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml
+++ b/extra/desktop/xfce4/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml
@@ -51,7 +51,7 @@
         <property name="workspace0" type="empty">
           <property name="color-style" type="int" value="0"/>
           <property name="image-style" type="int" value="5"/>
-          <property name="last-image" type="string" value="/usr/share/backgrounds/anarchy/faction.jpeg"/>
+          <property name="last-image" type="string" value="/usr/share/backgrounds/anarchy/Faction.jpeg"/>
         </property>
         <property name="workspace1" type="empty">
           <property name="color-style" type="int" value="0"/>


### PR DESCRIPTION
Noticed it was missing while testing fix for bug #529.

See https://github.com/deadhead420/anarchy-linux/issues/529#issuecomment-341693065