### PR TITLE
Removing Pacaur as it is unmaintained - french translation part.

### DIFF
--- a/lang/anarchy-french.conf
+++ b/lang/anarchy-french.conf
@@ -759,7 +759,7 @@ dm3="Gestionnaire de connexion SDDM"
 ### Anarchy repo
 aar0="Wiki d'Archlinux en CLI"
 aar1="Mise à jour des miroirs de Pacman"
-aar2="Interface pour les paquets AUR"
+#aar2="Interface pour les paquets AUR"
 aar3="Interface CLI pour AUR"
 aar4="Interface en qt5 pour Pacman et AUR"
 aar5="Interface en gtk3 pour Pacman et AUR"


### PR DESCRIPTION
Needs to be added right after this pull : https://github.com/deadhead420/anarchy-linux/pull/555

Cf bug #554 and https://www.reddit.com/r/archlinux/comments/7k5suz/pacaur_now_unmaintained/