### PR TITLE
fix ./anarchy-creator.sh 79 Row Too many argument

### DIFF
--- a/anarchy-creator.sh
+++ b/anarchy-creator.sh
@@ -76,7 +76,7 @@ check_depends() {
 	if [ ! -f /usr/bin/xxd ]; then query+="xxd "; fi
 	if [ ! -f /usr/bin/gtk3-demo ]; then query+="gtk3 "; fi
 
-	if [ ! -z $query ]; then
+	if [ ! -z "$query" ]; then
 		echo -en "Error: missing dependencies: ${query}\n > Install missing dependencies now? [y/N]: "
 		read -r input
 


### PR DESCRIPTION
This occuring when we have more then one dependecy to install during anarchy-creator.sh running
#595 