### PR TITLE
fix installation of terminus-font acpi zsh-syntax-highlighting

### DIFF
--- a/anarchy-creator.sh
+++ b/anarchy-creator.sh
@@ -248,7 +248,7 @@ build_conf() {
 build_sys() {
 
 	### Install fonts, fbterm, fetchmirrors, arch-wiki
-	sudo pacman --root $sq --cachedir $sq/var/cache/pacman/pkg  --config $paconf --gpgdir $sq/etc/pacman.d/gnupg --noconfirm -Sy terminus-font acpi zsh-syntax-highlighting
+	sudo pacman --root $sq --cachedir $sq/var/cache/pacman/pkg  --config $paconf --noconfirm -Sy terminus-font acpi zsh-syntax-highlighting
 	sudo pacman --root $sq --cachedir $sq/var/cache/pacman/pkg  --config $paconf --noconfirm -U /tmp/fetchmirrors/*.pkg.tar.xz
 	sudo pacman --root $sq --cachedir $sq/var/cache/pacman/pkg  --config $paconf --noconfirm -U /tmp/arch-wiki-cli/*.pkg.tar.xz
 	sudo pacman --root $sq --cachedir $sq/var/cache/pacman/pkg  --config $paconf -Sl | awk '/\[installed\]$/ {print $1 "/" $2 "-" $3}' > "$customiso"/arch/pkglist.${sys}.txt


### PR DESCRIPTION
Installation of packages in line

`
sudo pacman --root $sq --cachedir $sq/var/cache/pacman/pkg  --config $paconf --gpgdir $sq/etc/pacman.d/gnupg --noconfirm -Sy terminus-font acpi zsh-syntax-highlighting
`

is failing now with

`
warning: Public keyring not found; have you run 'pacman-key --init'?
downloading required keys...
error: key "A6234074498E9CEE" could not be looked up remotely
error: key "94657AB20F2A092B" could not be looked up remotely
error: key "A5E9288C4FA415FA" could not be looked up remotely
error: key "786C63F330D7CB92" could not be looked up remotely
error: key "976AC6FA3B94FA10" could not be looked up remotely
error: key "E62F853100F0D0F0" could not be looked up remotely
error: key "FCF3C8CB5CF9C8D4" could not be looked up remotely
error: key "2E89012331361F01" could not be looked up remotely
error: required key missing from keyring
error: failed to commit transaction (unexpected error)
Errors occurred, no packages were upgraded.
`

because pacman keyring is absence in squashfs and we have 3 options
* set SigLevel = Never in $sq/etc/pacman.conf while we installing packages
* create keyring with --init and populate it with arch public keys and remove it later
* just reuse pacman keyring on the host Arch by removing option --gpgdir