### PR TITLE
Add missing space if you need to install depends

### DIFF
--- a/anarchy-creator.sh
+++ b/anarchy-creator.sh
@@ -68,7 +68,7 @@ init() {
 check_depends() {
 
 	# Check depends
-	if [ ! -f /usr/bin/wget ]; then query="$query wget"; fi
+	if [ ! -f /usr/bin/wget ]; then query="$query wget "; fi
 	if [ ! -f /usr/bin/xorriso ]; then query+="libisoburn "; fi
 	if [ ! -f /usr/bin/mksquashfs ]; then query+="squashfs-tools "; fi
 	if [ ! -f /usr/bin/7z ]; then query+="p7zip " ; fi


### PR DESCRIPTION
When I tried to launch script in a virtual machine, script was looking for wgetlibisoburn instead of wget libisoburn... :(