### PR TITLE
Removing qt4 lines as VLC is now QT5 based

### DIFF
--- a/lib/configure_base.sh
+++ b/lib/configure_base.sh
@@ -488,9 +488,6 @@ add_software() {
 					if [ "$?" -gt "0" ]; then
 						add_soft=false
 					fi
-					if (<<<"$software" grep "vlc") then
-						software+=" qt4 phonon-qt4-vlc"
-					fi
 					if (<<<"$software" grep "multimedia-codecs") then
 						software=$(<<<"$software" sed 's/multimedia-codecs/gst-plugins-bad gst-plugins-base gst-plugins-good gst-plugins-ugly ffmpegthumbnailer gst-libav/')
 					fi


### PR DESCRIPTION
In order to fix this issue : https://github.com/deadhead420/anarchy-linux/issues/650