### PR TITLE
QupZilla became Falkon

### DIFF
--- a/lib/configure_desktop.sh
+++ b/lib/configure_desktop.sh
@@ -148,7 +148,7 @@ graphics() {
 							DE+="powerdevil "
 						fi
 					else
-						DE+="plasma ark aspell-en cdrdao clementine dolphin dolphin-plugins ffmpegthumbs gwenview k3b kate kcalc kdialog kfind kdeconnect kdegraphics-thumbnailers kdenetwork-filesharing kdesu kdelibs4support kipi-plugins khelpcenter konsole kwalletmanager okular spectacle transmission-qt krita kolourpaint korganizer knetattach qupzilla kdenlive "
+						DE+="plasma ark aspell-en cdrdao clementine dolphin dolphin-plugins ffmpegthumbs gwenview k3b kate kcalc kdialog kfind kdeconnect kdegraphics-thumbnailers kdenetwork-filesharing kdesu kdelibs4support kipi-plugins khelpcenter konsole kwalletmanager okular spectacle transmission-qt krita kolourpaint korganizer knetattach falkon kdenlive "
 					fi
 
 					if [ -n "$kdel" ]; then


### PR DESCRIPTION
Unable to install with complete default KDE-Plasma desktop caused by the nonexistent 'cupzilla' package became 'falkon' package. 