### PR TITLE
Removing gtk3-print-backends

### DIFF
--- a/lib/configure_base.sh
+++ b/lib/configure_base.sh
@@ -641,7 +641,7 @@ add_software() {
 					fi
 
 					if (grep "cups" <<<"$software" &>/dev/null); then
-						software=$(<<<"$software" sed 's/cups/cups cups-pdf gtk3-print-backends/')
+						software=$(<<<"$software" sed 's/cups/cups cups-pdf/')
 						if (dialog --yes-button "$yes" --no-button "$no" --yesno "\n$cups_msg" 10 60) then
 							enable_cups=true
 						fi


### PR DESCRIPTION
Package is not longer available. Merged with main gtk3 package. 

See this commit from november 2017: https://git.archlinux.org/svntogit/packages.git/commit/trunk?h=packages/gtk3&id=54e7af64837e18355122e62ff565970620db3537