### PR TITLE
Fixing bug #712

### DIFF
--- a/anarchy-creator.sh
+++ b/anarchy-creator.sh
@@ -333,7 +333,7 @@ build_sys_gui() {
 
 configure_boot() {
 
-	archiso_label=$(<"$customiso"/loader/entries/archiso-x86_64.conf awk 'NR==5{print $NF}' | sed 's/.*=//')
+	archiso_label=$(<"$customiso"/loader/entries/archiso-x86_64.conf awk 'NR==6{print $NF}' | sed 's/.*=//')
 	archiso_hex=$(<<<"$archiso_label" xxd -p)
 	iso_hex=$(<<<"$iso_label" xxd -p)
 	cp "$aa"/boot/splash.png "$customiso"/arch/boot/syslinux


### PR DESCRIPTION
An one liner fix for bug #712

As amd-ucode was added into /loaders/entries.conf, you needed to tweak a little the creator script. Even if you can't get a fully installable ISO, at least is boots!