### PR TITLE
Fixing GUI ISO creation (bug #637)

### DIFF
--- a/anarchy-creator.sh
+++ b/anarchy-creator.sh
@@ -186,9 +186,6 @@ build_conf() {
 	else
 		cd "$customiso"/arch/"$sys" || exit
 		sudo unsquashfs airootfs.sfs
-		sudo mount -t proc proc "$sq"/proc/
-		sudo mount -t sysfs sys "$sq"/sys/
-		sudo mount -o bind /dev "$sq"/dev/
 		sudo cp "$sq"/etc/mkinitcpio.conf "$sq"/etc/mkinitcpio.conf.bak
 		sudo cp "$sq"/etc/mkinitcpio-archiso.conf "$sq"/etc/mkinitcpio.conf
 	fi
@@ -270,6 +267,11 @@ build_sys() {
 
 build_sys_gui() {
 
+	## activating mount points needed by this section
+        sudo mount -t proc proc "$sq"/proc/
+        sudo mount -t sysfs sys "$sq"/sys/
+        sudo mount -o bind /dev "$sq"/dev/
+
 	### Blacklist vbox drivers so they are not loaded on non-vbox
 	echo 'FILES="/etc/modprobe.d/blacklist.conf"' | sudo tee -a "$sq"/etc/mkinitcpio.conf > /dev/null
 	echo 'FILES="/etc/modprobe.d/blacklist.conf"' | sudo tee -a "$sq"/etc/mkinitcpio-archiso.conf > /dev/null
@@ -287,6 +289,11 @@ build_sys_gui() {
 	sudo pacman --root "$sq" --cachedir "$sq"/var/cache/pacman/pkg  --config $paconf --noconfirm -Scc
 	sudo rm -f "$sq"/var/cache/pacman/pkg/*
 	sudo mv "$sq"/etc/mkinitcpio.conf.bak "$sq"/etc/mkinitcpio.conf
+	
+	## mount points are not longer needed because they are conflicting with arch-chroot.
+        sudo umount "$sq"/proc/
+        sudo umount "$sq"/sys/
+        sudo umount "$sq"/dev/
 
 	### Copy new kernel
 	sudo rm "$sq"/boot/initramfs-linux-fallback.img


### PR DESCRIPTION
At least a first - and definitive - fix for this old bug.

Some explanations.

Since arch-install-script v18, arch-chroot sets up mount point as needed. So mount lines where useless. I noticed when I kept mount lines, locale-gen was not run when invoking anarchy-creator.sh -g.

So i had to move mount point activation and deactivation around pacman lines in build_sys_gui() function.

I know it is not the best fix for this bug, but at least, it works :)