### PR TITLE
Fixing bug #647

### DIFF
--- a/lib/configure_base.sh
+++ b/lib/configure_base.sh
@@ -19,7 +19,7 @@ install_options() {
 
 	op_title="$install_op_msg"
         while (true) ; do
-                 install_opt=$(dialog --ok-button "$ok" --cancel-button "$cancel" --menu "$install_opt_msg" 16 72 5 \
+                 install_opt=$(dialog --ok-button "$ok" --cancel-button "$cancel" --menu "$install_opt_msg" 16 80 5 \
                          "Anarchy-Desktop"       "$install_opt1" \
                          "Anarchy-Desktop-LTS"   "$install_opt2" \
                          "Anarchy-Server"        "$install_opt3" \


### PR DESCRIPTION
All $install_op_msg options are readable at once. "Advanced options" is not hidden anymore. So old bug #647 can be closed as fixed.