### PR TITLE
Removing Amarok and inxi

### DIFF
--- a/lib/configure_base.sh
+++ b/lib/configure_base.sh
@@ -352,7 +352,6 @@ add_software() {
 				;;
 				"$audio")
 					software=$(dialog --ok-button "$ok" --cancel-button "$cancel" --checklist "$software_msg1" 20 63 10 \
-						"amarok"		"$audio12" OFF \
 						"audacity"		"$audio0" OFF \
 						"audacious"		"$audio1" OFF \
 						"clementine"		"$audio10" OFF \


### PR DESCRIPTION
Both are now on AUR. See: https://aur.archlinux.org/packages/amarok/ and https://aur.archlinux.org/packages/inxi/