### PR TITLE
Add fonts to installable software.

### DIFF
--- a/etc/anarchy.conf
+++ b/etc/anarchy.conf
@@ -304,6 +304,10 @@ net10="GTK-based IRC client"
 net11="GTK-based IRC client"
 net12="Lightweight web browser"
 
+### Fonts
+font0="Unicode fonts"
+font1="Fonts which support CN, JP, KR"
+
 ### Games
 game0="Free FPS focused mainly on online multiplayer"
 game1="Port of classic BSD command line games"

--- a/lang/anarchy-bulgarian.conf
+++ b/lang/anarchy-bulgarian.conf
@@ -599,6 +599,10 @@ text_editor="Текстови Редактори"
 
 text_editor_msg="Софтуер за текстови редактори =>"
 
+fonts="Fonts"
+
+fonts_msg="Linux Fonts =>"
+
 games="Игри"
 
 games_msg="Линукс игри =>"

--- a/lang/anarchy-chinese.conf
+++ b/lang/anarchy-chinese.conf
@@ -431,6 +431,10 @@ system="系统"
 
 system_msg="系统工具 =>"
 
+fonts="Fonts"
+
+fonts_msg="Linux Fonts =>"
+
 games="游戏"
 
 games_msg="Linux 游戏 =>"

--- a/lang/anarchy-dutch.conf
+++ b/lang/anarchy-dutch.conf
@@ -609,6 +609,10 @@ text_editor="Text Editors"
 
 text_editor_msg="Text Editing Software =>"
 
+fonts="Fonts"
+
+fonts_msg="Linux Fonts =>"
+
 games="Games"
 
 games_msg="Linux Games =>"

--- a/lang/anarchy-english.conf
+++ b/lang/anarchy-english.conf
@@ -567,6 +567,10 @@ servers="Server"
 
 servers_msg="Server software =>"
 
+fonts="Fonts"
+
+fonts_msg="Linux Fonts =>"
+
 games="Games"
 
 games_msg="Linux Games =>"

--- a/lang/anarchy-french.conf
+++ b/lang/anarchy-french.conf
@@ -842,6 +842,10 @@ servers="Serveur"
 
 servers_msg="Logiciels pour serveur =>"
 
+fonts="Fonts"
+
+fonts_msg="Linux Fonts =>"
+
 games="Jeux"
 
 games_msg="Jeux pour Linux =>"

--- a/lang/anarchy-german.conf
+++ b/lang/anarchy-german.conf
@@ -588,6 +588,10 @@ servers="Server"
 
 servers_msg="Serversoftware =>"
 
+fonts="Fonts"
+
+fonts_msg="Linux Fonts =>"
+
 games="Spiele"
 
 games_msg="Spiele =>"

--- a/lang/anarchy-greek.conf
+++ b/lang/anarchy-greek.conf
@@ -618,6 +618,10 @@ text_editor_msg="Λογισμικό Επεξεργασίας Κειμένου =>
 
 #system_msg="Εργαλεία Συστήματος =>"
 
+fonts="Fonts"
+
+fonts_msg="Linux Fonts =>"
+
 games="Παιχνίδια"
 
 games_msg="Παιχνίδια Linux =>"

--- a/lang/anarchy-hungarian.conf
+++ b/lang/anarchy-hungarian.conf
@@ -605,6 +605,10 @@ text_editor_msg="Szövegszerkesző Szoftver =>"
 
 #system_msg="Rendszerkellékek =>"
 
+fonts="Fonts"
+
+fonts_msg="Linux Fonts =>"
+
 games="Játékok"
 
 games_msg="Linux Játékok =>"

--- a/lang/anarchy-indonesia.conf
+++ b/lang/anarchy-indonesia.conf
@@ -613,6 +613,10 @@ text_editor="Pengedit Teks"
 
 text_editor_msg="Perangkat Lunak Pengedit Teks>"
 
+fonts="Fonts"
+
+fonts_msg="Linux Fonts =>"
+
 games="Permainan"
 
 games_msg="Permainan Linux>"

--- a/lang/anarchy-italian.conf
+++ b/lang/anarchy-italian.conf
@@ -607,6 +607,10 @@ system="Sistema"
 
 system_msg="Strumenti di sistema =>"
 
+fonts="Fonts"
+
+fonts_msg="Linux Fonts =>"
+
 games="Giochi"
 
 games_msg="Giochi Linux =>"

--- a/lang/anarchy-latvian.conf
+++ b/lang/anarchy-latvian.conf
@@ -605,6 +605,10 @@ system="Sistēma"
 
 system_msg="Sistēmas rīki =>"
 
+fonts="Fonts"
+
+fonts_msg="Linux Fonts =>"
+
 games="Spēles"
 
 games_msg="Linux spēles =>"

--- a/lang/anarchy-lithuanian.conf
+++ b/lang/anarchy-lithuanian.conf
@@ -603,6 +603,10 @@ system="Sistema"
 
 system_msg="Sistemos tvarkyklės =>"
 
+fonts="Fonts"
+
+fonts_msg="Linux Fonts =>"
+
 games="Žaidimai"
 
 games_msg="Linux Žaidimai =>"

--- a/lang/anarchy-polish.conf
+++ b/lang/anarchy-polish.conf
@@ -604,6 +604,10 @@ system="System"
 
 system_msg="Narzędzia systemowe =>"
 
+fonts="Fonts"
+
+fonts_msg="Linux Fonts =>"
+
 games="Gry"
 
 games_msg="Gry na Linux =>"

--- a/lang/anarchy-portuguese-br.conf
+++ b/lang/anarchy-portuguese-br.conf
@@ -606,6 +606,10 @@ servers="Servidor"
 
 servers_msg="Programas do servidor =>"
 
+fonts="Fonts"
+
+fonts_msg="Linux Fonts =>"
+
 games="Jogos"
 
 games_msg="Jogos do Linux>"

--- a/lang/anarchy-portuguese.conf
+++ b/lang/anarchy-portuguese.conf
@@ -380,6 +380,10 @@ text_editor="Text Editors"
 
 text_editor_msg="Text Editing Software =>"
 
+fonts="Fonts"
+
+fonts_msg="Linux Fonts =>"
+
 games="Games"
 
 games_msg="Linux Games =>"

--- a/lang/anarchy-romanian.conf
+++ b/lang/anarchy-romanian.conf
@@ -587,6 +587,10 @@ servers="Server"
 
 servers_msg="Utilitare Server >"
 
+fonts="Fonts"
+
+fonts_msg="Linux Fonts =>"
+
 games="Jocuri"
 
 games_msg="Jocuri Linux =>"

--- a/lang/anarchy-russian.conf
+++ b/lang/anarchy-russian.conf
@@ -605,6 +605,10 @@ system="System"
 
 system_msg="System Utilities =>"
 
+fonts="Fonts"
+
+fonts_msg="Linux Fonts =>"
+
 games="Games"
 
 games_msg="Linux Games =>"

--- a/lang/anarchy-spanish.conf
+++ b/lang/anarchy-spanish.conf
@@ -593,6 +593,10 @@ servers="Servidor"
 
 servers_msg="Software de servidor =>"
 
+fonts="Fonts"
+
+fonts_msg="Linux Fonts =>"
+
 games="Juegos"
 
 games_msg="Juegos de Linux>"

--- a/lang/anarchy-swedish.conf
+++ b/lang/anarchy-swedish.conf
@@ -654,6 +654,10 @@ system="System"
 
 system_msg="System Program>"
 
+fonts="Fonts"
+
+fonts_msg="Linux Fonts =>"
+
 games="Spel"
 
 games_msg="Linux Spel>"

--- a/lib/configure_base.sh
+++ b/lib/configure_base.sh
@@ -278,6 +278,7 @@ add_software() {
 					"$aar"		"$aar_msg" \
 					"$audio"	"$audio_msg" \
 					"$database"	"$database_msg" \
+					"$fonts"	"$fonts_msg" \
 					"$games"	"$games_msg" \
 					"$graphic"	"$graphic_msg" \
 					"$internet"	"$internet_msg" \
@@ -412,6 +413,14 @@ add_software() {
 
 					if (<<<"$software" grep "thunderbird" &>/dev/null) && [ -n "$bro" ] && [ "$bro" != "lv" ]; then
 							software+=" thunderbird-i18n-$bro"
+					fi
+				;;
+				"$fonts")
+					software=$(dialog --ok-button "$ok" --cancel-button "$cancel" --checklist "$software_msg1" 20 63 10 \
+						"bdf-unifont"		"$font0" OFF \
+						"noto-fonts-cjk"	"$font1" OFF 3>&1 1>&2 2>&3)
+					if [ "$?" -gt "0" ]; then
+						add_soft=false
 					fi
 				;;
 				"$games")


### PR DESCRIPTION
Font added to installation option.
This will prevent garbled characters in East Asian languages after installation.

Default.
[https://i.imgur.com/e3W5b5r.jpg](https://i.imgur.com/e3W5b5r.jpg)

After font installation.
[https://i.imgur.com/MEe1Y0n.jpg](https://i.imgur.com/MEe1Y0n.jpg)