### PR TITLE
Get a full list of options in Install Desktop step

### DIFF
--- a/lib/configure_desktop.sh
+++ b/lib/configure_desktop.sh
@@ -26,7 +26,7 @@ graphics() {
 
 	while (true)
 	  do
-		de=$(dialog --ok-button "$done_msg" --cancel-button "$cancel" --menu "$environment_msg" 16 60 7 \
+		de=$(dialog --ok-button "$done_msg" --cancel-button "$cancel" --menu "$environment_msg" 16 75 7 \
 			"Anarchy-budgie"	"$de24" \
 			"Anarchy-cinnamon"	"$de23" \
 			"Anarchy-gnome"		"$de22" \


### PR DESCRIPTION
A simple fix to get the full list of options in Install Desktop step. No need to scroll anymore to get all options :)

See this attached screenshot:

![virtualbox_anarchy 1 0 2 beta_30_09_2018_21_06_51](https://user-images.githubusercontent.com/8571419/46261534-2ca76680-c4f5-11e8-9df8-927085e3d089.png)
