### PR TITLE
Bundle unifont.

### DIFF
--- a/etc/anarchy.conf
+++ b/etc/anarchy.conf
@@ -310,7 +310,7 @@ net11="GTK-based IRC client"
 net12="Lightweight web browser"
 
 ### Fonts
-font0="Unicode fonts"
+# font0="Unicode fonts"
 font1="Fonts which support CN, JP, KR"
 
 ### Games

--- a/lang/anarchy-french.conf
+++ b/lang/anarchy-french.conf
@@ -143,7 +143,7 @@ net11="Client chat(IRC) en GTK"
 net12="Navigateur internet léger"
 
 ### Fonts
-font0="Polices Unicode"
+# font0="Polices Unicode"
 font1="Polices supportant CN, JP, KR"
 
 ### Games

--- a/lib/configure_desktop.sh
+++ b/lib/configure_desktop.sh
@@ -387,6 +387,7 @@ config_env() {
 	cp -r "$aa_dir"/extra/fonts/ttf-zekton-rg "$ARCH"/usr/share/fonts
 	chmod -R 755 "$ARCH"/usr/share/fonts/ttf-zekton-rg
 	arch-chroot "$ARCH" fc-cache -f
+	cp "$aa_dir"/extra/fonts/unifont/unifont-11.0.02.ttf "$ARCH"/usr/share/fonts/TTF
 	cp "$aa_dir"/extra/anarchy-icon.png "$ARCH"/root/.face
 	cp "$aa_dir"/extra/anarchy-icon.png "$ARCH"/etc/skel/.face
 	cp "$aa_dir"/extra/anarchy-icon.png "$ARCH"/usr/share/pixmaps


### PR DESCRIPTION
With this change, garbled characters are resolved in all languages immediately after installation.
'bdf-unifont' is not recognized by some software such as browser, so 'ttf-unifont' is bundled instead. Since unifont's license is GPLv2, there is no problem with the bundle.
http://unifoundry.com/unifont/index.html