### PR TITLE
Removed MongoDB from optional software list

### DIFF
--- a/etc/anarchy.conf
+++ b/etc/anarchy.conf
@@ -15,10 +15,10 @@
 ###############################################################
 ### This is the Anarchy Linux configuration file it is
 ### responsible for defining some variables in the Anarchy
-### installer. This file generally should not be edited unless 
+### installer. This file generally should not be edited unless
 ### for a very specific purpose.
 ###
-### Anarchy Linux translators may, if they wish, copy the 
+### Anarchy Linux translators may, if they wish, copy the
 ### software messages in the catagories listed below into their
 ### translation. You may copy the variables and paste them at
 ### the bottom of the 'menu_msg' function in your translation.
@@ -107,9 +107,9 @@ case "$opt" in
 		usage ; exit
 	;;
 	-n|--no-style)
-		colors=false 
+		colors=false
 	;;
-	-k|--keys)	
+	-k|--keys)
 		echo -e "${Yellow}*> Anarchy: Updating pacman keys..."
 		pacman-db-upgrade
 		pacman-key --init
@@ -120,10 +120,10 @@ case "$opt" in
 			exit 1
 		else
 			echo -e "${Green}*> Updated: ${Yellow}Updated pacman keys successfully."
-			exit 
+			exit
 		fi
 	;;
-	-u|--update) 
+	-u|--update)
                 tmp_dir=$(mktemp -d)
 		echo -ne "\n${Yellow}*> Anarchy: Downloading..."
 		wget -q -4 --no-check-certificate -O $tmp_dir/master.tar.gz https://github.com/deadhead420/anarchy-linux/archive/master.tar.gz
@@ -185,11 +185,11 @@ de_defaults="xdg-user-dirs xorg-server xorg-apps xorg-xinit xterm ttf-dejavu gvf
 extras="gvfs arc-gtk-theme elementary-icon-theme numix-icon-theme-git numix-circle-icon-theme-git htop arch-wiki-cli lynx fetchmirrors chromium libreoffice-fresh vlc gnome-packagekit pantheon-music"
 
 ### Graphics Drivers
-gr1="Vesa $os $drivers" 
-gr2="NVIDIA $drivers" 
-gr4="AMD/ATI $os $drivers" 
-gr5="Intel $os $drivers" 
-gr6="NVIDIA $drivers" 
+gr1="Vesa $os $drivers"
+gr2="NVIDIA $drivers"
+gr4="AMD/ATI $os $drivers"
+gr5="Intel $os $drivers"
+gr6="NVIDIA $drivers"
 gr7="NVIDIA 340xx $drivers"
 gr8="NVIDIA $os $drivers"
 gr9="NVIDIA 390xx $drivers"
@@ -284,7 +284,7 @@ audio14="Music playback application"
 
 ### Database
 db0="A document-oriented database"
-db1="High-performance, open source database"
+#db1="High-performance, open source database"
 db2="SQL server implimentation"
 db3="Sqlite module for PHP"
 db4="Advanced key-value store"
@@ -349,8 +349,8 @@ media3="Screen capture software"
 media4="A free front-end for MPlayer"
 media5="GNOME media player"
 media6="VLC graphical media player"
-media7="Media player-MPlayer based" 
-media8="Multimedia codecs" 
+media7="Media player-MPlayer based"
+media8="Multimedia codecs"
 media9="Full featured video editor for Linux"
 media10="Screencast GIF tool"
 media11="Powerful and simple media player"

--- a/lib/configure_base.sh
+++ b/lib/configure_base.sh
@@ -376,7 +376,6 @@ add_software() {
 					software=$(dialog --ok-button "$ok" --cancel-button "$cancel" --checklist "$software_msg1" 20 63 10 \
 						"couchdb"		"$db0" OFF \
 						"mariadb"		"$sys30" OFF \
-						"mongodb"		"$db1" OFF \
 						"percona-server"	"$db2" OFF \
 						"phpmyadmin"		"$sys32" OFF \
 						"php-sqlite"		"$db3" OFF \
@@ -384,6 +383,8 @@ add_software() {
 						"redis"			"$db4" OFF \
 						"rethinkdb"		"$db5" OFF\
 						"sqlite"		"$db6" OFF 3>&1 1>&2 2>&3)
+						# MongoDB has been removed from the official repositories due to its re-licensing issues
+						# "mongodb"		"$db1" OFF
 					if [ "$?" -gt "0" ]; then
 						add_soft=false
 					fi


### PR DESCRIPTION
MongoDB has been removed from the official repositories due to its re-licensing issues [[1]](https://lists.archlinux.org/pipermail/arch-dev-public/2019-January/029430.html).