### PR TITLE
Fixes issue where LUKS encrypted XFS root will not boot

### DIFF
--- a/lib/configure_device.sh
+++ b/lib/configure_device.sh
@@ -854,6 +854,8 @@ fs_select() {
 		enable_f2fs=true
 	elif [ "$FS" == "btrfs" ]; then
 		enable_btrfs=true
+  elif [ "$FS" == "xfs" ]; then
+		enable_xfs=true
 	fi
 
 }

--- a/lib/configure_system.sh
+++ b/lib/configure_system.sh
@@ -71,6 +71,15 @@ configure_system() {
 		echo "$(date -u "+%F %H:%M") : Configure system for f2fs" >> "$log"
 	fi
 
+  if "$enable_xfs" ; then
+		sed -i '/MODULES=/ s/.$/ xfs )/;s/" /"/' "$ARCH"/etc/mkinitcpio.conf
+		if ! "$crypted" ; then
+			arch-chroot "$ARCH" mkinitcpio -p "$kernel" &>/dev/null &
+			pid=$! pri=1 msg="\n$xfs_config_load \n\n \Z1> \Z2mkinitcpio -p $kernel\Zn" load
+		fi
+		echo "$(date -u "+%F %H:%M") : Configure system for xfs" >> "$log"
+	fi
+
 	if (<<<"$BOOT" egrep "nvme.*" &> /dev/null) then
 		sed -i 's/MODULES="/MODULES="nvme /;s/ "/"/' "$ARCH"/etc/mkinitcpio.conf
 		if ! "$crypted" ; then

--- a/lib/configure_system.sh
+++ b/lib/configure_system.sh
@@ -40,7 +40,7 @@ configure_system() {
 	fi
 
 	if "$drm" ; then
-		sed -i 's/MODULES=""/MODULES="nvidia nvidia_modeset nvidia_uvm nvidia_drm"/' "$ARCH"/etc/mkinitcpio.conf
+    sed -i '/^MODULES=/ s/.$/ nvidia nvidia_modeset nvidia_uvm nvidia_drm )/;s/" /"/'
 		sed -i 's!FILES=""!FILES="/etc/modprobe.d/nvidia.conf"!' "$ARCH"/etc/mkinitcpio.conf
 		echo "options nvidia_drm modeset=1" > "$ARCH"/etc/modprobe.d/nvidia.conf
 
@@ -63,7 +63,7 @@ configure_system() {
 	fi
 
 	if "$enable_f2fs" ; then
-		sed -i '/MODULES=/ s/.$/ f2fs crc32 libcrc32c crc32c_generic crc32c-intel crc32-pclmul"/;s/" /"/' "$ARCH"/etc/mkinitcpio.conf
+		sed -i '/^MODULES=/ s/.$/ f2fs crc32 libcrc32c crc32c_generic crc32c-intel crc32-pclmul )/;s/" /"/' "$ARCH"/etc/mkinitcpio.conf
 		if ! "$crypted" ; then
 			arch-chroot "$ARCH" mkinitcpio -p "$kernel" &>/dev/null &
 			pid=$! pri=1 msg="\n$f2fs_config_load \n\n \Z1> \Z2mkinitcpio -p $kernel\Zn" load
@@ -72,7 +72,7 @@ configure_system() {
 	fi
 
   if "$enable_xfs" ; then
-		sed -i '/MODULES=/ s/.$/ xfs )/;s/" /"/' "$ARCH"/etc/mkinitcpio.conf
+		sed -i '/^MODULES=/ s/.$/ xfs )/;s/" /"/' "$ARCH"/etc/mkinitcpio.conf
 		if ! "$crypted" ; then
 			arch-chroot "$ARCH" mkinitcpio -p "$kernel" &>/dev/null &
 			pid=$! pri=1 msg="\n$xfs_config_load \n\n \Z1> \Z2mkinitcpio -p $kernel\Zn" load
@@ -81,7 +81,7 @@ configure_system() {
 	fi
 
 	if (<<<"$BOOT" egrep "nvme.*" &> /dev/null) then
-		sed -i 's/MODULES="/MODULES="nvme /;s/ "/"/' "$ARCH"/etc/mkinitcpio.conf
+		sed -i '/^MODULES=/ s/.$/ nvme )/;s/" /"/' "$ARCH"/etc/mkinitcpio.conf
 		if ! "$crypted" ; then
 			arch-chroot "$ARCH" mkinitcpio -p "$kernel" &>/dev/null &
 			pid=$! pri=1 msg="\n$kernel_config_load \n\n \Z1> \Z2mkinitcpio -p $kernel\Zn" load


### PR DESCRIPTION
Issue is fixed by adding "xfs" to the "MODULES" list in
/etc/mkinitcpio.conf

See the following link for XFS and LUKS:
https://bbs.archlinux.org/viewtopic.php?pid=1748083#p1748083s://bbs.archlinux.org/viewtopic.php?pid=1748083#p1748083

NOTE:
I've changed the `sed` line from:
`sed -i '/MODULES=/ s/.$/ xfs"/;s/" /"/' "$ARCH"/etc/mkinitcpio.conf`

to:
`sed -i '/MODULES=/ s/.$/ xfs )/;s/" /"/' "$ARCH"/etc/mkinitcpio.conf`

The effect of the first example is:
```
...
#     MODULES=(piix ide_disk reiserfs xfs"
MODULES=( xfs"
...
```

and the effect of the changed line is:
```
...
#     MODULES=(piix ide_disk reiserfs xfs )
MODULES=( xfs )
...
```

Which brings up the points:
A) Am I missing something?
B) If not, then should all `sed` lines involving the `MODULES=` line in `mkinitcpio.conf` be changed to add a closing parentheses, rather than a space and a double quote?